### PR TITLE
Fix/elastic target create

### DIFF
--- a/targets/elastic.js
+++ b/targets/elastic.js
@@ -43,12 +43,16 @@ module.exports = (stream,argv,schema) => {
       // Try creating the index with settings and mappings (if defined)
       if (settings)
         ['provided_name','creation_date','uuid', 'version'].forEach(f => delete settings.index[f]);
+      if (mapping) {
+        mapping[argv.target_indextype] = mapping[argv.source_indextype]
+        delete mapping[argv.source_indextype]
+      }
+
       return client.indices.create({
         index: argv.target_index,
-        type: argv.target_indextype,
         body: {
           settings: settings,
-          mapping: mapping 
+          mappings: mapping
         }
       })
       .then(

--- a/targets/elastic.js
+++ b/targets/elastic.js
@@ -41,6 +41,8 @@ module.exports = (stream,argv,schema) => {
     })
     .then(() => Promise.join(settings,mapping, (settings,mapping) => {
       // Try creating the index with settings and mappings (if defined)
+      if (settings)
+        ['provided_name','creation_date','uuid', 'version'].forEach(f => delete settings.index[f]);
       return client.indices.create({
         index: argv.target_index,
         type: argv.target_indextype,


### PR DESCRIPTION
* Removes settings fields from the source index that can't be used to create another index
* Removes invalid `type` parameter in `indices.create`
* Renames `mapping[source_indextype]` to `mapping[target_indextype]`