### PR TITLE
Better scan on target/files and target/s3files

### DIFF
--- a/output.js
+++ b/output.js
@@ -266,8 +266,8 @@ module.exports = async function(obj, argv) {
   const res = { Σ_in, Σ_out };
   if (argv.test) {
     res.data = argv.test;
-    Object.defineProperty(res, 'argv', { value: argv });
   }
+  Object.defineProperty(res, 'argv', { value: argv });
   if (argv.Σ_skipped) res.Σ_skipped = argv.Σ_skipped;
   return res;
 };

--- a/targets/s3files.js
+++ b/targets/s3files.js
@@ -21,8 +21,6 @@ module.exports = async function(stream, argv) {
 
   const query = { Bucket, Prefix };
 
-  // --target_overwrite   or --target_skip_scan
-
   argv.target_files_scanned = false;
 
   if (!config.overwrite && !config.skip_scan) {

--- a/test/files-test.js
+++ b/test/files-test.js
@@ -50,6 +50,39 @@ tap.test('files', async t => {
     t.same(res, { 'Σ_in': 2, 'Σ_out': 2 });
   });
 
+  t.test('writing files again', async () => {
+    const cmd = `etl files/${__dirname}/support/testfiles files/${tmpDir}/testfiles/ --silent`;
+    const res = await cli(cmd);
+    t.same(res, { 'Σ_in': 2, 'Σ_out': 2, Σ_skipped: 2 });
+  });
+
+  t.test('writing files again via params', async () => {
+    const cmd = `etl files --source_dir=${__dirname}/support/testfiles files --target_dir=${tmpDir}/testfiles/ --silent`;
+    const res = await cli(cmd);
+    t.same(res, { 'Σ_in': 2, 'Σ_out': 2, Σ_skipped: 2 });
+  });
+
+  t.test('writing files skipping scan', async () => {
+    const cmd = `etl files/${__dirname}/support/testfiles files/${tmpDir}/testfiles/ --silent --target_skip_scan=true`;
+    const res = await cli(cmd);
+    t.same(res.argv.target_files_scanned, false);
+    t.same(res, { 'Σ_in': 2, 'Σ_out': 2, Σ_skipped: 2 });
+  });
+
+  t.test('writing files await scan', async () => {
+    const cmd = `etl files/${__dirname}/support/testfiles files/${tmpDir}/testfiles/ --silent --target_await_scan=true`;
+    const res = await cli(cmd);
+    t.same(res.argv.target_files_scanned, true);
+    t.same(res, { 'Σ_in': 2, 'Σ_out': 2, Σ_skipped: 2 });
+  });
+
+  t.test('writing files with overwrite', async () => {
+    const cmd = `etl files/${__dirname}/support/testfiles files/${tmpDir}/testfiles/ --silent --target_overwrite=true`;
+    const res = await cli(cmd);
+    t.same(res.argv.target_files_scanned, false);
+    t.same(res, { 'Σ_in': 2, 'Σ_out': 2 });
+  });
+
   t.test('reading them back', async () => {
     const cmd = `etl files/${tmpDir}/testfiles test --silent`;
     const res = await cli(cmd);

--- a/test/s3-test.js
+++ b/test/s3-test.js
@@ -42,6 +42,33 @@ tap.test('s3files', async t => {
     t.same(res, { Σ_in: 2, Σ_out: 2, Σ_skipped: 2 }, 'skips uploading files that already exist');
   });
 
+
+  t.test('uploading files again to s3 via params', async t => {
+    const cmd = `etl files/${__dirname}/support/testfiles s3files --target_bucket=${Bucket} --target_prefix="test/subdirectory" --target_endpoint=http://localhost:9090 --target_forcePathStyle=true`;
+    const res = await cli(cmd);
+    t.same(res, { Σ_in: 2, Σ_out: 2, Σ_skipped: 2 }, 'skips uploading files that already exist');
+  });
+
+  t.test('uploading files again to s3 skipping scan', async t => {
+    const cmd = `etl files/${__dirname}/support/testfiles s3files/${Bucket}/test/subdirectory --target_endpoint=http://localhost:9090 --target_forcePathStyle=true --target_skip_scan=true`;
+    const res = await cli(cmd);
+    t.same(res.argv.target_files_scanned, false);
+    t.same(res, { Σ_in: 2, Σ_out: 2, Σ_skipped: 2 }, 'skips uploading files that already exist');
+  });
+
+  t.test('uploading files again to s3 awaiting scan', async t => {
+    const cmd = `etl files/${__dirname}/support/testfiles s3files/${Bucket}/test/subdirectory --target_endpoint=http://localhost:9090 --target_forcePathStyle=true --target_await_scan=true`;
+    const res = await cli(cmd);
+    t.same(res.argv.target_files_scanned, true);
+    t.same(res, { Σ_in: 2, Σ_out: 2, Σ_skipped: 2 }, 'skips uploading files that already exist');
+  });
+
+  t.test('uploading files again to s3 with target_overwrite', async t => {
+    const cmd = `etl files/${__dirname}/support/testfiles s3files/${Bucket}/test/subdirectory --target_endpoint=http://localhost:9090 --target_forcePathStyle=true --target_overwrite=true`;
+    const res = await cli(cmd);
+    t.same(res, { Σ_in: 2, Σ_out: 2 }, 'overwrite files that already exist');
+  });
+
   t.test('downloading files from s3', async t => {
     const cmd = `etl s3files/${Bucket}/test test --silent --source_endpoint=http://localhost:9090 --source_forcePathStyle=true`;
     const res = await cli(cmd);


### PR DESCRIPTION
Improve scanning of files to check if they already exists and should be skipped
* The scanning is done in the background. non-blocking
* If scanning is not complete, we compare to files found so far and if not found do a fs.stat or s3.getHead operation to see if the file exists